### PR TITLE
Add some new helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,72 +2,219 @@
 
 > Convenience functions for Web Bluetooth
 
-
 ## Install
 
-```
-$ npm install --save web-bluetooth-utils
-```
-
-
-## Usage
-
-```js
-navigator.bluetooth.requestDevice({ filters: [{ services: ['battery_service'] }] })
-.then(device => device.gatt.connect())
-.then(server => server.getPrimaryService('battery_service'))
-.then(service => service.getCharacteristic('battery_level'))
-.then(characteristic => {
-  return characteristic.readValue()
-    .then(value => {
-       // Before..
-       console.log('Battery percentage is ' + value.getUint8(0));
-       // Now...
-       console.log('Battery percentage is ' + characteristic.getUint8Value(0));
-    })
-})
+```shell
+npm install --save web-bluetooth-utils
 ```
 
+## Example usage
+
+```diff
+ navigator.bluetooth.requestDevice({ filters: [{ services: ['battery_service'] }] })
+-.then(device => device.gatt.connect())
+-.then(server => server.getPrimaryService('battery_service'))
+-.then(service => service.getCharacteristic('battery_level'))
+-.then(characteristic => characteristic.readValue())
++.then(device => device.readUint8CharacteristicValueFromPrimaryService('battery_service', 'battery_level', 0 /* offset */))
+ .then(value => {
+-  console.log('Battery percentage is ' + value.getUint8(0));
++  console.log('Battery percentage is ' + value));
+ });
+```
 
 ## API
 
-### BluetoothRemoteGATTCharacteristic.getFloat32Value (byteOffset, littleEndian = true)
+### Characteristic.getFloat32Value
+
+```js
+BluetoothRemoteGATTCharacteristic.getFloat32Value(byteOffset, littleEndian = true)
+```
 
 Returns the cached value of the characteristic as a signed 32-bit float (float) at the specified byte offset.
 
-### BluetoothRemoteGATTCharacteristic.getFloat64Value (byteOffset, littleEndian = true)
+### Characteristic.getFloat64Value
+
+```js
+BluetoothRemoteGATTCharacteristic.getFloat64Value(byteOffset, littleEndian = true)
+```
 
 Returns the cached value of the characteristic as a signed 64-bit float (double) at the specified byte offset.
 
-### BluetoothRemoteGATTCharacteristic.getInt16Value (byteOffset, littleEndian = true)
+### Characteristic.getInt16Value
+
+```js
+BluetoothRemoteGATTCharacteristic.getInt16Value(byteOffset, littleEndian = true)
+```
 
 Returns the cached value of the characteristic as a signed 16-bit integer (short) at the specified byte offset.
 
-### BluetoothRemoteGATTCharacteristic.getInt32Value (byteOffset, littleEndian = true)
+### Characteristic.getInt32Value
+
+```js
+BluetoothRemoteGATTCharacteristic.getInt32Value(byteOffset, littleEndian = true)
+```
 
 Returns the cached value of the characteristic as a signed 32-bit integer (long) at the specified byte offset.
 
-### BluetoothRemoteGATTCharacteristic.getInt8Value (byteOffset)
+### Characteristic.getInt8Value
+
+```js
+BluetoothRemoteGATTCharacteristic.getInt8Value(byteOffset)
+```
 
 Returns the cached value of the characteristic as a signed 8-bit integer (byte) at the specified byte offset.
 
-### BluetoothRemoteGATTCharacteristic.getStringValue (encoding = 'utf8')
+### Characteristic.getStringValue
+
+```js
+BluetoothRemoteGATTCharacteristic.getStringValue(encoding = 'utf8')
+```
 
 Returns the cached value of the characteristic as a string containing the text decoded with the decoding algorithm.
 
-### BluetoothRemoteGATTCharacteristic.getUint16Value (byteOffset, littleEndian = true)
+### Characteristic.getUint16Value
+
+```js
+BluetoothRemoteGATTCharacteristic.getUint16Value(byteOffset, littleEndian = true)
+```
 
 Returns the cached value of the characteristic as an unsigned 16-bit integer (unsigned short) at the specified byte offset.
 
-### BluetoothRemoteGATTCharacteristic.getUint32Value (byteOffset, littleEndian = true)
+### Characteristic.getUint32Value
+
+```js
+BluetoothRemoteGATTCharacteristic.getUint32Value(byteOffset, littleEndian = true)
+```
 
 Returns the cached value of the characteristic as an unsigned 32-bit integer (unsigned long) at the specified byte offset.
 
-### BluetoothRemoteGATTCharacteristic.getUint8Value (byteOffset)
+### Characteristic.getUint8Value
+
+```js
+BluetoothRemoteGATTCharacteristic.getUint8Value(byteOffset)
+```
 
 Returns the cached value of the characteristic as an unsigned 8-bit integer (unsigned byte) at the specified byte offset.
 
-### BluetoothRemoteGATTService.getCharacteristics (characteristics)
+### Service.getCharacteristics
+
+```js
+BluetoothRemoteGATTService.getCharacteristics(characteristics)
+```
 
 If `characteristics` is an Array, returns all service's characteristics matching all characteristics UUIDs.
 If `characteristics` is a String, returns all service's characteristics matching the unique UUID.
+
+### Device.getCharacteristicFromPrimaryService
+
+```js
+BluetoothDevice.getCharacteristicFromPrimaryService(serviceUuid, characteristicUuid)
+```
+
+Returns the characteristic from a primary service.
+
+### Device.readCharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.readCharacteristicValueFromPrimaryService(serviceUuid, characteristicUuid, optionalCallback, optionalArgs)
+```
+
+Reads the value of a characteristic from a primary service as a `DataView` object.
+If `optionalCallback` is passed, it will be called with the characteristic value and `optionalArgs` arguments.
+
+### Device.readFloat32CharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.readFloat32CharacteristicValueFromPrimaryService(serviceUuid, characteristicUuid, byteOffset, littleEndian = true)
+```
+
+Reads the value of the characteristic from a primary service as a signed 32-bit float (float) at the specified byte offset.
+
+### Device.readFloat64CharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.readFloat64CharacteristicValueFromPrimaryService(serviceUuid, characteristicUuid, byteOffset, littleEndian = true)
+```
+
+Reads the value of the characteristic from a primary service as a signed 64-bit float (double) at the specified byte offset.
+
+### Device.readInt16CharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.readInt16CharacteristicValueFromPrimaryService
+```
+
+Reads the value of the characteristic from a primary service as a signed 16-bit integer (short) at the specified byte offset.
+
+### Device.readInt32CharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.readInt32CharacteristicValueFromPrimaryService(serviceUuid, characteristicUuid, byteOffset, littleEndian = true)
+```
+
+Reads the value of the characteristic from a primary service as a signed 32-bit integer (long) at the specified byte offset.
+
+### Device.readInt8CharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.readInt8CharacteristicValueFromPrimaryService(serviceUuid, characteristicUuid, byteOffset)
+```
+
+Reads the value of the characteristic from a primary service as a signed 8-bit integer (byte) at the specified byte offset.
+
+### Device.readStringCharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.readStringCharacteristicValueFromPrimaryService(serviceUuid, characteristicUuid, byteOffset)
+```
+
+Reads the value of the characteristic from a primary service as a string containing the text decoded with the decoding algorithm.
+
+### Device.readUint16CharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.readUint16CharacteristicValueFromPrimaryService(serviceUuid, characteristicUuid, byteOffset, littleEndian = true)
+```
+
+Reads the value of the characteristic from a primary service as an unsigned 16-bit integer (unsigned short) at the specified byte offset.
+
+### Device.readUint32CharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.readUint32CharacteristicValueFromPrimaryService(serviceUuid, characteristicUuid, byteOffset, littleEndian = true)
+```
+
+Reads the value of the characteristic from a primary service as an unsigned 32-bit integer (unsigned long) at the specified byte offset.
+
+### Device.readUint8CharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.readUint8CharacteristicValueFromPrimaryService(serviceUuid, characteristicUuid, byteOffset)
+```
+
+Reads the value of the characteristic from a primary service as an unsigned 8-bit integer (unsigned byte) at the specified byte offset.
+
+### Device.writeCharacteristicValueFromPrimaryService
+
+```js
+BluetoothDevice.writeCharacteristicValueFromPrimaryService(serviceUuid, characteristicUuid, data)
+```
+
+Writes data to a characteristic from a primary service.
+
+### Device.startCharacteristicNotificationsFromPrimaryService
+
+```js
+BluetoothDevice.startCharacteristicNotificationsFromPrimaryService(serviceUuid, characteristicUuid, listener)
+```
+
+Start notifications from a characteristic from a primary service and attach an event listener.
+
+### Device.stopCharacteristicNotificationsFromPrimaryService
+
+```js
+BluetoothDevice.stopCharacteristicNotificationsFromPrimaryService(serviceUuid, characteristicUuid, listener)
+```
+
+Stop notifications from a characteristic from a primary service and remove an event listener.

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ self.BluetoothRemoteGATTCharacteristic.prototype.getUint8Value = function(byteOf
   return this.value.getUint8(byteOffset);
 };
 
+(function(exports) {
 let nativeGetCharacteristics = BluetoothRemoteGATTService.prototype.getCharacteristics;
 let getCharacteristics = function(characteristics) {
   if (characteristics instanceof Array) {
@@ -46,4 +47,82 @@ let getCharacteristics = function(characteristics) {
   return nativeGetCharacteristics.apply(this, [characteristics]);
 }
 
-self.BluetoothRemoteGATTService.prototype.getCharacteristics = getCharacteristics;
+exports.BluetoothRemoteGATTService.prototype.getCharacteristics = getCharacteristics;
+})(self);
+
+self.BluetoothDevice.prototype.getCharacteristicFromPrimaryService = function(serviceUuid, characteristicUuid) {
+  return Promise.resolve()
+  .then(_ => this.gatt.connect())
+  .then(server => server.getPrimaryService(serviceUuid))
+  .then(service => service.getCharacteristic(characteristicUuid));
+}
+
+self.BluetoothDevice.prototype.readCharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, optionalCallback, optionalArgs) {
+  return this.getCharacteristicFromPrimaryService(serviceUuid, characteristicUuid)
+  .then(characteristic => {
+    return characteristic.readValue()
+    .then(value => optionalCallback ? optionalCallback.apply(characteristic, optionalArgs) : value);
+  });
+};
+
+self.BluetoothDevice.prototype.readFloat32CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset, littleEndian = true) {
+  return this.readCharacteristicValueFromPrimaryService(characteristicUuid, serviceUuid,
+      self.BluetoothRemoteGATTCharacteristic.prototype.getFloat32Value, [byteOffset, littleEndian]);
+}
+
+self.BluetoothDevice.prototype.readFloat64CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset, littleEndian = true) {
+  return this.readCharacteristicValueFromPrimaryService(characteristicUuid, serviceUuid,
+      self.BluetoothRemoteGATTCharacteristic.prototype.getFloat64Value, [byteOffset, littleEndian]);
+}
+
+self.BluetoothDevice.prototype.readInt16CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset, littleEndian = true) {
+  return this.readCharacteristicValueFromPrimaryService(characteristicUuid, serviceUuid,
+      self.BluetoothRemoteGATTCharacteristic.prototype.getInt16Value, [byteOffset, littleEndian]);
+}
+
+self.BluetoothDevice.prototype.readInt32CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset, littleEndian = true) {
+  return this.readCharacteristicValueFromPrimaryService(characteristicUuid, serviceUuid,
+      self.BluetoothRemoteGATTCharacteristic.prototype.getInt32Value, [byteOffset, littleEndian]);
+}
+
+self.BluetoothDevice.prototype.readInt8CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset) {
+  return this.readCharacteristicValueFromPrimaryService(characteristicUuid, serviceUuid,
+      self.BluetoothRemoteGATTCharacteristic.prototype.getInt8Value, [byteOffset]);
+}
+
+self.BluetoothDevice.prototype.readStringCharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset) {
+  return this.readCharacteristicValueFromPrimaryService(characteristicUuid, serviceUuid,
+      self.BluetoothRemoteGATTCharacteristic.prototype.getStringValue);
+}
+
+self.BluetoothDevice.prototype.readUint16CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset, littleEndian = true) {
+  return this.readCharacteristicValueFromPrimaryService(characteristicUuid, serviceUuid,
+      self.BluetoothRemoteGATTCharacteristic.prototype.getUint16Value, [byteOffset, littleEndian]);
+}
+
+self.BluetoothDevice.prototype.readUint32CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset, littleEndian = true) {
+  return this.readCharacteristicValueFromPrimaryService(characteristicUuid, serviceUuid,
+      self.BluetoothRemoteGATTCharacteristic.prototype.getUint32Value, [byteOffset, littleEndian]);
+}
+
+self.BluetoothDevice.prototype.readUint8CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset) {
+  return this.readCharacteristicValueFromPrimaryService(characteristicUuid, serviceUuid,
+      self.BluetoothRemoteGATTCharacteristic.prototype.getUint8Value, [byteOffset]);
+}
+
+self.BluetoothDevice.prototype.writeCharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, data) {
+  return this.getCharacteristicFromPrimaryService(serviceUuid, characteristicUuid)
+  .then(characteristic => characteristic.writeValue(data));
+};
+
+self.BluetoothDevice.prototype.startCharacteristicNotificationsFromPrimaryService = function(serviceUuid, characteristicUuid, listener) {
+  return this.getCharacteristicFromPrimaryService(serviceUuid, characteristicUuid)
+  .then(characteristic => characteristic.startNotifications())
+  .then(characteristic => characteristic.addEventListener('characteristicvaluechanged', listener));
+};
+
+self.BluetoothDevice.prototype.stopCharacteristicNotificationsFromPrimaryService = function(serviceUuid, characteristicUuid, listener) {
+  return this.getCharacteristicFromPrimaryService(serviceUuid, characteristicUuid)
+  .then(characteristic => characteristic.stopNotifications())
+  .then(characteristic => characteristic.removeEventListener('characteristicvaluechanged', listener));
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-bluetooth-utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Convenience functions for Web Bluetooth",
   "license": "Apache-2.0",
   "repository": "beaufortfrancois/web-bluetooth-utils",


### PR DESCRIPTION
This patch adds new helper methods such as:

```js
self.BluetoothDevice.prototype.getCharacteristicFromPrimaryService = function(serviceUuid, characteristicUuid) {}
self.BluetoothDevice.prototype.readCharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, optionalCallback, optionalArgs) {}
self.BluetoothDevice.prototype.readFloat32CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset, littleEndian = true) {}
self.BluetoothDevice.prototype.readFloat64CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset, littleEndian = true) {}
self.BluetoothDevice.prototype.readStringCharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset) {}
self.BluetoothDevice.prototype.readUint16CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset, littleEndian = true) {}
self.BluetoothDevice.prototype.readUint32CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset, littleEndian = true) {}
self.BluetoothDevice.prototype.readUint8CharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, byteOffset) {}
self.BluetoothDevice.prototype.writeCharacteristicValueFromPrimaryService = function(serviceUuid, characteristicUuid, data) {}
self.BluetoothDevice.prototype.startCharacteristicNotificationsFromPrimaryService = function(serviceUuid, characteristicUuid, listener) {}
self.BluetoothDevice.prototype.stopCharacteristicNotificationsFromPrimaryService = function(serviceUuid, characteristicUuid, listener) {}
```